### PR TITLE
Add plan statistics and create Category/BudgetItem models (US-011)

### DIFF
--- a/app/api/v1/endpoints/plans.py
+++ b/app/api/v1/endpoints/plans.py
@@ -16,8 +16,7 @@ async def create_plan(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    plan = await plan_crud.create_plan(db, user_id=current_user.id, plan_create=plan_create)
-    return plan
+    return await plan_crud.create_plan(db, user_id=current_user.id, plan_create=plan_create)
 
 
 @router.get("/", response_model=list[PlanResponse])
@@ -25,7 +24,7 @@ async def get_plans(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    return await plan_crud.get_plans_by_user(db, user_id=current_user.id)
+    return await plan_crud.get_plans_with_stats(db, user_id=current_user.id)
 
 
 @router.get("/{plan_id}", response_model=PlanResponse)
@@ -39,4 +38,5 @@ async def get_plan(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plan not found")
     if plan.user_id != current_user.id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to access this plan")
-    return plan
+    plan_with_stats = await plan_crud.get_plan_with_stats(db, plan_id=plan_id)
+    return plan_with_stats

--- a/app/crud/plan.py
+++ b/app/crud/plan.py
@@ -1,12 +1,13 @@
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import select, func, case
 from typing import Optional
 
 from app.models.plan import Plan
+from app.models.budget_item import BudgetItem, BudgetItemType, PaymentRhythm
 from app.schemas.plan import PlanCreate
 
 
-async def create_plan(db: AsyncSession, user_id: int, plan_create: PlanCreate) -> Plan:
+async def create_plan(db: AsyncSession, user_id: int, plan_create: PlanCreate) -> dict:
     db_plan = Plan(
         user_id=user_id,
         name=plan_create.name,
@@ -15,16 +16,70 @@ async def create_plan(db: AsyncSession, user_id: int, plan_create: PlanCreate) -
     db.add(db_plan)
     await db.commit()
     await db.refresh(db_plan)
-    return db_plan
+    return _plan_to_dict(db_plan, 0, 0.0, 0.0)
 
 
-async def get_plans_by_user(db: AsyncSession, user_id: int) -> list[Plan]:
-    result = await db.execute(
+async def get_plans_with_stats(db: AsyncSession, user_id: int) -> list[dict]:
+    plans = await db.execute(
         select(Plan).where(Plan.user_id == user_id).order_by(Plan.created_at.desc())
     )
-    return list(result.scalars().all())
+    plans = list(plans.scalars().all())
+
+    result = []
+    for plan in plans:
+        stats = await _get_plan_stats(db, plan.id)
+        result.append(_plan_to_dict(plan, *stats))
+    return result
+
+
+async def get_plan_with_stats(db: AsyncSession, plan_id: int) -> Optional[dict]:
+    plan_result = await db.execute(select(Plan).where(Plan.id == plan_id))
+    plan = plan_result.scalars().first()
+    if not plan:
+        return None
+    stats = await _get_plan_stats(db, plan.id)
+    return _plan_to_dict(plan, *stats)
 
 
 async def get_plan_by_id(db: AsyncSession, plan_id: int) -> Optional[Plan]:
     result = await db.execute(select(Plan).where(Plan.id == plan_id))
     return result.scalars().first()
+
+
+async def _get_plan_stats(db: AsyncSession, plan_id: int) -> tuple[int, float, float]:
+    monthly_amount_expr = case(
+        (BudgetItem.payment_rhythm == PaymentRhythm.MONTHLY, BudgetItem.amount),
+        (BudgetItem.payment_rhythm == PaymentRhythm.QUARTERLY, BudgetItem.amount / 3),
+        (BudgetItem.payment_rhythm == PaymentRhythm.SEMI_ANNUALLY, BudgetItem.amount / 6),
+        (BudgetItem.payment_rhythm == PaymentRhythm.ANNUALLY, BudgetItem.amount / 12),
+        else_=0,
+    )
+
+    result = await db.execute(
+        select(
+            func.count(BudgetItem.id).label("count"),
+            func.coalesce(
+                func.sum(case((BudgetItem.type == BudgetItemType.INCOME, monthly_amount_expr), else_=0)), 0
+            ).label("income"),
+            func.coalesce(
+                func.sum(case((BudgetItem.type == BudgetItemType.EXPENSE, monthly_amount_expr), else_=0)), 0
+            ).label("expenses"),
+        ).where(BudgetItem.plan_id == plan_id)
+    )
+    row = result.one()
+    return int(row.count), float(row.income), float(row.expenses)
+
+
+def _plan_to_dict(plan: Plan, count: int, income: float, expenses: float) -> dict:
+    return {
+        "id": plan.id,
+        "user_id": plan.user_id,
+        "name": plan.name,
+        "description": plan.description,
+        "created_at": plan.created_at,
+        "updated_at": plan.updated_at,
+        "budget_item_count": count,
+        "total_monthly_income": round(income, 2),
+        "total_monthly_expenses": round(expenses, 2),
+        "monthly_balance": round(income - expenses, 2),
+    }

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,7 @@
 from app.core.database import Base
 from app.models.user import User
 from app.models.plan import Plan
+from app.models.category import Category
+from app.models.budget_item import BudgetItem
 
-__all__ = ["Base", "User", "Plan"]
+__all__ = ["Base", "User", "Plan", "Category", "BudgetItem"]

--- a/app/models/budget_item.py
+++ b/app/models/budget_item.py
@@ -1,0 +1,59 @@
+import enum
+from decimal import Decimal
+
+from sqlalchemy import Column, Integer, String, Text, DateTime, Numeric, Enum, ForeignKey, CheckConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+
+class BudgetItemType(str, enum.Enum):
+    INCOME = "income"
+    EXPENSE = "expense"
+
+
+class PaymentRhythm(str, enum.Enum):
+    MONTHLY = "monthly"
+    QUARTERLY = "quarterly"
+    SEMI_ANNUALLY = "semi_annually"
+    ANNUALLY = "annually"
+
+
+class BudgetItem(Base):
+    __tablename__ = "budget_items"
+    __table_args__ = (
+        CheckConstraint("amount > 0", name="check_amount_positive"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    plan_id = Column(Integer, ForeignKey("plans.id", ondelete="CASCADE"), nullable=False, index=True)
+    category_id = Column(Integer, ForeignKey("categories.id"), nullable=False, index=True)
+    description = Column(String(200), nullable=False)
+    amount = Column(Numeric(10, 2), nullable=False)
+    type = Column(Enum(BudgetItemType), nullable=False)
+    payment_rhythm = Column(Enum(PaymentRhythm), nullable=False)
+    note = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    plan = relationship("Plan", back_populates="budget_items")
+    category = relationship("Category", back_populates="budget_items")
+
+    def calculate_monthly_amount(self) -> Decimal:
+        if self.payment_rhythm == PaymentRhythm.MONTHLY:
+            return Decimal(self.amount)
+        elif self.payment_rhythm == PaymentRhythm.QUARTERLY:
+            return Decimal(self.amount) / Decimal(3)
+        elif self.payment_rhythm == PaymentRhythm.SEMI_ANNUALLY:
+            return Decimal(self.amount) / Decimal(6)
+        elif self.payment_rhythm == PaymentRhythm.ANNUALLY:
+            return Decimal(self.amount) / Decimal(12)
+        return Decimal(0)
+
+    @property
+    def monthly_amount(self) -> Decimal:
+        return self.calculate_monthly_amount()
+
+    def __repr__(self):
+        return f"<BudgetItem(id={self.id}, description='{self.description}', amount={self.amount})>"

--- a/app/models/category.py
+++ b/app/models/category.py
@@ -1,0 +1,27 @@
+import enum
+
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, Enum
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+
+class CategoryType(str, enum.Enum):
+    INCOME = "income"
+    EXPENSE = "expense"
+
+
+class Category(Base):
+    __tablename__ = "categories"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), unique=True, nullable=False)
+    type = Column(Enum(CategoryType), nullable=False)
+    is_system = Column(Boolean, default=False, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    budget_items = relationship("BudgetItem", back_populates="category")
+
+    def __repr__(self):
+        return f"<Category(id={self.id}, name='{self.name}', type='{self.type}')>"

--- a/app/models/plan.py
+++ b/app/models/plan.py
@@ -16,6 +16,7 @@ class Plan(Base):
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 
     user = relationship("User", back_populates="plans")
+    budget_items = relationship("BudgetItem", back_populates="plan", cascade="all, delete-orphan")
 
     def __repr__(self):
         return f"<Plan(id={self.id}, name='{self.name}')>"

--- a/app/schemas/plan.py
+++ b/app/schemas/plan.py
@@ -20,6 +20,10 @@ class PlanResponse(BaseModel):
     description: Optional[str] = None
     created_at: datetime
     updated_at: datetime
+    budget_item_count: int = 0
+    total_monthly_income: float = 0.0
+    total_monthly_expenses: float = 0.0
+    monthly_balance: float = 0.0
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
- Add Category model (income/expense type, is_system flag)

- Add BudgetItem model with payment rhythm and monthly calculation

- Extend GET /plans and GET /plans/{id} with statistics (budget_item_count, total_monthly_income/expenses, monthly_balance)

- Calculate monthly amounts via SQL CASE expression

- Add Plan -> BudgetItem relationship with cascade delete