### PR TITLE
Add plan update endpoint (US-012)

### DIFF
--- a/app/api/v1/endpoints/plans.py
+++ b/app/api/v1/endpoints/plans.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
 from app.crud import plan as plan_crud
-from app.schemas.plan import PlanCreate, PlanResponse
+from app.schemas.plan import PlanCreate, PlanUpdate, PlanResponse
 from app.api.deps import get_current_user
 from app.models.user import User
 
@@ -40,3 +40,19 @@ async def get_plan(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to access this plan")
     plan_with_stats = await plan_crud.get_plan_with_stats(db, plan_id=plan_id)
     return plan_with_stats
+
+
+@router.put("/{plan_id}", response_model=PlanResponse)
+async def update_plan(
+    plan_id: int,
+    plan_update: PlanUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    plan = await plan_crud.get_plan_by_id(db, plan_id=plan_id)
+    if not plan:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plan not found")
+    if plan.user_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to access this plan")
+    await plan_crud.update_plan(db, plan=plan, plan_update=plan_update)
+    return await plan_crud.get_plan_with_stats(db, plan_id=plan_id)

--- a/app/crud/plan.py
+++ b/app/crud/plan.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from app.models.plan import Plan
 from app.models.budget_item import BudgetItem, BudgetItemType, PaymentRhythm
-from app.schemas.plan import PlanCreate
+from app.schemas.plan import PlanCreate, PlanUpdate
 
 
 async def create_plan(db: AsyncSession, user_id: int, plan_create: PlanCreate) -> dict:
@@ -39,6 +39,15 @@ async def get_plan_with_stats(db: AsyncSession, plan_id: int) -> Optional[dict]:
         return None
     stats = await _get_plan_stats(db, plan.id)
     return _plan_to_dict(plan, *stats)
+
+
+async def update_plan(db: AsyncSession, plan: Plan, plan_update: PlanUpdate) -> Plan:
+    update_data = plan_update.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(plan, field, value)
+    await db.commit()
+    await db.refresh(plan)
+    return plan
 
 
 async def get_plan_by_id(db: AsyncSession, plan_id: int) -> Optional[Plan]:


### PR DESCRIPTION
- Add PUT /api/v1/plans/{plan_id} for updating name and description

- Add update_plan CRUD function with partial update support

- Ownership check ensures users can only edit their own plans