### PR TITLE
Add plan delete endpoint (US-013)

### DIFF
--- a/app/api/v1/endpoints/plans.py
+++ b/app/api/v1/endpoints/plans.py
@@ -56,3 +56,17 @@ async def update_plan(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to access this plan")
     await plan_crud.update_plan(db, plan=plan, plan_update=plan_update)
     return await plan_crud.get_plan_with_stats(db, plan_id=plan_id)
+
+
+@router.delete("/{plan_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_plan(
+    plan_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    plan = await plan_crud.get_plan_by_id(db, plan_id=plan_id)
+    if not plan:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plan not found")
+    if plan.user_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to access this plan")
+    await plan_crud.delete_plan(db, plan=plan)

--- a/app/crud/plan.py
+++ b/app/crud/plan.py
@@ -50,6 +50,11 @@ async def update_plan(db: AsyncSession, plan: Plan, plan_update: PlanUpdate) -> 
     return plan
 
 
+async def delete_plan(db: AsyncSession, plan: Plan) -> None:
+    await db.delete(plan)
+    await db.commit()
+
+
 async def get_plan_by_id(db: AsyncSession, plan_id: int) -> Optional[Plan]:
     result = await db.execute(select(Plan).where(Plan.id == plan_id))
     return result.scalars().first()


### PR DESCRIPTION
- Add DELETE /api/v1/plans/{plan_id} with ownership check

- Cascade delete removes all associated budget items