### PR TITLE
Add categories API with default seeding (US-030)

### DIFF
--- a/app/api/v1/api.py
+++ b/app/api/v1/api.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter
-from app.api.v1.endpoints import auth, plans
+from app.api.v1.endpoints import auth, plans, categories
 
 api_router = APIRouter()
 
 api_router.include_router(auth.router, prefix="/auth", tags=["Authentication"])
 api_router.include_router(plans.router, prefix="/plans", tags=["Plans"])
+api_router.include_router(categories.router, prefix="/categories", tags=["Categories"])

--- a/app/api/v1/endpoints/categories.py
+++ b/app/api/v1/endpoints/categories.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Optional
+
+from app.core.database import get_db
+from app.crud import category as category_crud
+from app.schemas.category import CategoryResponse
+from app.api.deps import get_current_user
+from app.models.user import User
+from app.models.category import CategoryType
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[CategoryResponse])
+async def get_categories(
+    type: Optional[CategoryType] = Query(None, description="Filter by type: income or expense"),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    if type:
+        return await category_crud.get_categories_by_type(db, category_type=type)
+    return await category_crud.get_all_categories(db)

--- a/app/crud/category.py
+++ b/app/crud/category.py
@@ -1,0 +1,51 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.models.category import Category, CategoryType
+
+
+async def get_all_categories(db: AsyncSession) -> list[Category]:
+    result = await db.execute(select(Category).order_by(Category.type, Category.name))
+    return list(result.scalars().all())
+
+
+async def get_categories_by_type(db: AsyncSession, category_type: CategoryType) -> list[Category]:
+    result = await db.execute(
+        select(Category).where(Category.type == category_type).order_by(Category.name)
+    )
+    return list(result.scalars().all())
+
+
+async def seed_default_categories(db: AsyncSession) -> None:
+    result = await db.execute(select(Category).where(Category.is_system == True))
+    if result.scalars().first() is not None:
+        return
+
+    defaults = [
+        # Einnahmen
+        ("Gehalt", CategoryType.INCOME),
+        ("Nebenverdienst", CategoryType.INCOME),
+        ("Sonstiges", CategoryType.INCOME),
+        # Ausgaben
+        ("Miete", CategoryType.EXPENSE),
+        ("Lebenshaltung", CategoryType.EXPENSE),
+        ("Telefon/Internet", CategoryType.EXPENSE),
+        ("Vermögensabsicherung", CategoryType.EXPENSE),
+        ("Persönliche Absicherung", CategoryType.EXPENSE),
+        ("Freizeit", CategoryType.EXPENSE),
+        ("Urlaub", CategoryType.EXPENSE),
+        ("Sport", CategoryType.EXPENSE),
+        ("ÖPNV", CategoryType.EXPENSE),
+        ("Abonnements", CategoryType.EXPENSE),
+        ("Studium", CategoryType.EXPENSE),
+        ("Vermögensaufbau", CategoryType.EXPENSE),
+        ("Altersvorsorge", CategoryType.EXPENSE),
+        ("Kredite/Darlehen", CategoryType.EXPENSE),
+        ("Konsum", CategoryType.EXPENSE),
+        ("Sonstige", CategoryType.EXPENSE),
+    ]
+
+    for name, cat_type in defaults:
+        db.add(Category(name=name, type=cat_type, is_system=True))
+
+    await db.commit()

--- a/app/main.py
+++ b/app/main.py
@@ -4,15 +4,18 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.core.database import engine
+from app.core.database import engine, AsyncSessionLocal
 from app.models import Base
 from app.api.v1.api import api_router
+from app.crud.category import seed_default_categories
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+    async with AsyncSessionLocal() as session:
+        await seed_default_categories(session)
     yield
 
 

--- a/app/schemas/category.py
+++ b/app/schemas/category.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+from datetime import datetime
+
+
+class CategoryResponse(BaseModel):
+    id: int
+    name: str
+    type: str
+    is_system: bool
+    created_at: datetime
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
- Add Category schema and CRUD operations

- Add GET /api/v1/categories with optional type filter

- Seed 19 default system categories on startup (3 income, 16 expense)

- Register categories router in API