### PR TITLE
Add budget items list endpoint (US-021)

### DIFF
--- a/app/api/v1/endpoints/budget_items.py
+++ b/app/api/v1/endpoints/budget_items.py
@@ -20,6 +20,16 @@ async def _get_plan_or_403(plan_id: int, current_user: User, db: AsyncSession):
     return plan
 
 
+@router.get("/", response_model=list[BudgetItemResponse])
+async def get_budget_items(
+    plan_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    await _get_plan_or_403(plan_id, current_user, db)
+    return await budget_item_crud.get_budget_items_by_plan(db, plan_id=plan_id)
+
+
 @router.post("/", response_model=BudgetItemResponse, status_code=status.HTTP_201_CREATED)
 async def create_budget_item(
     plan_id: int,

--- a/app/crud/budget_item.py
+++ b/app/crud/budget_item.py
@@ -5,6 +5,16 @@ from app.models.budget_item import BudgetItem
 from app.schemas.budget_item import BudgetItemCreate
 
 
+async def get_budget_items_by_plan(db: AsyncSession, plan_id: int) -> list[dict]:
+    result = await db.execute(
+        select(BudgetItem)
+        .where(BudgetItem.plan_id == plan_id)
+        .order_by(BudgetItem.type, BudgetItem.created_at)
+    )
+    items = result.scalars().all()
+    return [_item_to_dict(item) for item in items]
+
+
 async def create_budget_item(db: AsyncSession, plan_id: int, item_create: BudgetItemCreate) -> dict:
     db_item = BudgetItem(
         plan_id=plan_id,


### PR DESCRIPTION
- Add GET /api/v1/plans/{plan_id}/items/ to retrieve all budget

- items for a plan, sorted by type (income first) and creation date.