### PR TITLE
Add budget item update endpoint (US-022)

### DIFF
--- a/app/api/v1/endpoints/budget_items.py
+++ b/app/api/v1/endpoints/budget_items.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import get_db
 from app.crud import plan as plan_crud
 from app.crud import budget_item as budget_item_crud
-from app.schemas.budget_item import BudgetItemCreate, BudgetItemResponse
+from app.schemas.budget_item import BudgetItemCreate, BudgetItemUpdate, BudgetItemResponse
 from app.api.deps import get_current_user
 from app.models.user import User
 
@@ -39,3 +39,18 @@ async def create_budget_item(
 ):
     await _get_plan_or_403(plan_id, current_user, db)
     return await budget_item_crud.create_budget_item(db, plan_id=plan_id, item_create=item_create)
+
+
+@router.put("/{item_id}", response_model=BudgetItemResponse)
+async def update_budget_item(
+    plan_id: int,
+    item_id: int,
+    item_update: BudgetItemUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    await _get_plan_or_403(plan_id, current_user, db)
+    item = await budget_item_crud.get_budget_item_by_id(db, item_id=item_id)
+    if not item or item.plan_id != plan_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Budget item not found")
+    return await budget_item_crud.update_budget_item(db, item=item, item_update=item_update)

--- a/app/crud/budget_item.py
+++ b/app/crud/budget_item.py
@@ -2,7 +2,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 from app.models.budget_item import BudgetItem
-from app.schemas.budget_item import BudgetItemCreate
+from app.schemas.budget_item import BudgetItemCreate, BudgetItemUpdate
 
 
 async def get_budget_items_by_plan(db: AsyncSession, plan_id: int) -> list[dict]:
@@ -29,6 +29,20 @@ async def create_budget_item(db: AsyncSession, plan_id: int, item_create: Budget
     await db.commit()
     await db.refresh(db_item)
     return _item_to_dict(db_item)
+
+
+async def get_budget_item_by_id(db: AsyncSession, item_id: int) -> BudgetItem | None:
+    result = await db.execute(select(BudgetItem).where(BudgetItem.id == item_id))
+    return result.scalars().first()
+
+
+async def update_budget_item(db: AsyncSession, item: BudgetItem, item_update: BudgetItemUpdate) -> dict:
+    update_data = item_update.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(item, field, value)
+    await db.commit()
+    await db.refresh(item)
+    return _item_to_dict(item)
 
 
 def _item_to_dict(item: BudgetItem) -> dict:

--- a/app/schemas/budget_item.py
+++ b/app/schemas/budget_item.py
@@ -14,6 +14,15 @@ class BudgetItemCreate(BaseModel):
     note: Optional[str] = None
 
 
+class BudgetItemUpdate(BaseModel):
+    category_id: Optional[int] = None
+    description: Optional[str] = Field(None, min_length=1, max_length=200)
+    amount: Optional[float] = Field(None, gt=0)
+    type: Optional[BudgetItemType] = None
+    payment_rhythm: Optional[PaymentRhythm] = None
+    note: Optional[str] = None
+
+
 class BudgetItemResponse(BaseModel):
     id: int
     plan_id: int


### PR DESCRIPTION
- Add PUT /api/v1/plans/{plan_id}/items/{item_id} for editing budget items. All fields are optional (partial update).

- Monthly amount is automatically recalculated on changes.