### PR TITLE
Add custom category creation endpoint (US-031)

### DIFF
--- a/app/api/v1/endpoints/categories.py
+++ b/app/api/v1/endpoints/categories.py
@@ -1,10 +1,10 @@
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from typing import Optional
 
 from app.core.database import get_db
 from app.crud import category as category_crud
-from app.schemas.category import CategoryResponse
+from app.schemas.category import CategoryCreate, CategoryResponse
 from app.api.deps import get_current_user
 from app.models.user import User
 from app.models.category import CategoryType
@@ -21,3 +21,15 @@ async def get_categories(
     if type:
         return await category_crud.get_categories_by_type(db, category_type=type)
     return await category_crud.get_all_categories(db)
+
+
+@router.post("/", response_model=CategoryResponse, status_code=status.HTTP_201_CREATED)
+async def create_category(
+    category_create: CategoryCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    existing = await category_crud.get_category_by_name(db, name=category_create.name)
+    if existing:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Category name already exists")
+    return await category_crud.create_category(db, name=category_create.name, category_type=category_create.type)

--- a/app/crud/category.py
+++ b/app/crud/category.py
@@ -16,6 +16,19 @@ async def get_categories_by_type(db: AsyncSession, category_type: CategoryType) 
     return list(result.scalars().all())
 
 
+async def get_category_by_name(db: AsyncSession, name: str) -> Category | None:
+    result = await db.execute(select(Category).where(Category.name == name))
+    return result.scalars().first()
+
+
+async def create_category(db: AsyncSession, name: str, category_type: CategoryType) -> Category:
+    db_category = Category(name=name, type=category_type, is_system=False)
+    db.add(db_category)
+    await db.commit()
+    await db.refresh(db_category)
+    return db_category
+
+
 async def seed_default_categories(db: AsyncSession) -> None:
     result = await db.execute(select(Category).where(Category.is_system == True))
     if result.scalars().first() is not None:

--- a/app/schemas/category.py
+++ b/app/schemas/category.py
@@ -1,5 +1,12 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from datetime import datetime
+
+from app.models.category import CategoryType
+
+
+class CategoryCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+    type: CategoryType
 
 
 class CategoryResponse(BaseModel):


### PR DESCRIPTION
- Add POST /api/v1/categories/ for creating user-defined categories.

- Validates unique name constraint and marks them as non-system.