### PR TITLE
Add category rename endpoint (US-032)

### DIFF
--- a/app/api/v1/endpoints/categories.py
+++ b/app/api/v1/endpoints/categories.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from app.core.database import get_db
 from app.crud import category as category_crud
-from app.schemas.category import CategoryCreate, CategoryResponse
+from app.schemas.category import CategoryCreate, CategoryUpdate, CategoryResponse
 from app.api.deps import get_current_user
 from app.models.user import User
 from app.models.category import CategoryType
@@ -33,3 +33,19 @@ async def create_category(
     if existing:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Category name already exists")
     return await category_crud.create_category(db, name=category_create.name, category_type=category_create.type)
+
+
+@router.put("/{category_id}", response_model=CategoryResponse)
+async def update_category(
+    category_id: int,
+    category_update: CategoryUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    category = await category_crud.get_category_by_id(db, category_id=category_id)
+    if not category:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
+    existing = await category_crud.get_category_by_name(db, name=category_update.name)
+    if existing and existing.id != category_id:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Category name already exists")
+    return await category_crud.update_category(db, category=category, name=category_update.name)

--- a/app/crud/category.py
+++ b/app/crud/category.py
@@ -21,6 +21,18 @@ async def get_category_by_name(db: AsyncSession, name: str) -> Category | None:
     return result.scalars().first()
 
 
+async def get_category_by_id(db: AsyncSession, category_id: int) -> Category | None:
+    result = await db.execute(select(Category).where(Category.id == category_id))
+    return result.scalars().first()
+
+
+async def update_category(db: AsyncSession, category: Category, name: str) -> Category:
+    category.name = name
+    await db.commit()
+    await db.refresh(category)
+    return category
+
+
 async def create_category(db: AsyncSession, name: str, category_type: CategoryType) -> Category:
     db_category = Category(name=name, type=category_type, is_system=False)
     db.add(db_category)

--- a/app/schemas/category.py
+++ b/app/schemas/category.py
@@ -9,6 +9,10 @@ class CategoryCreate(BaseModel):
     type: CategoryType
 
 
+class CategoryUpdate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=100)
+
+
 class CategoryResponse(BaseModel):
     id: int
     name: str


### PR DESCRIPTION
- Add PUT /api/v1/categories/{category_id} for renaming categories.

- Validates unique name constraint. Budget items stay linked via ID.