### PR TITLE
Add category delete endpoint (US-033)

### DIFF
--- a/app/api/v1/endpoints/categories.py
+++ b/app/api/v1/endpoints/categories.py
@@ -49,3 +49,28 @@ async def update_category(
     if existing and existing.id != category_id:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Category name already exists")
     return await category_crud.update_category(db, category=category, name=category_update.name)
+
+
+@router.delete("/{category_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_category(
+    category_id: int,
+    reassign_to: Optional[int] = Query(None, description="Category ID to reassign budget items to"),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    category = await category_crud.get_category_by_id(db, category_id=category_id)
+    if not category:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Category not found")
+    if category.is_system:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="System categories cannot be deleted")
+    item_count = await category_crud.count_budget_items_by_category(db, category_id=category_id)
+    if item_count > 0 and not reassign_to:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Category has {item_count} budget item(s). Provide reassign_to parameter or remove items first.",
+        )
+    if reassign_to:
+        target = await category_crud.get_category_by_id(db, category_id=reassign_to)
+        if not target:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Reassign target category not found")
+    await category_crud.delete_category(db, category=category, reassign_to_id=reassign_to)

--- a/app/crud/category.py
+++ b/app/crud/category.py
@@ -1,7 +1,8 @@
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select
+from sqlalchemy import select, func, update
 
 from app.models.category import Category, CategoryType
+from app.models.budget_item import BudgetItem
 
 
 async def get_all_categories(db: AsyncSession) -> list[Category]:
@@ -31,6 +32,24 @@ async def update_category(db: AsyncSession, category: Category, name: str) -> Ca
     await db.commit()
     await db.refresh(category)
     return category
+
+
+async def count_budget_items_by_category(db: AsyncSession, category_id: int) -> int:
+    result = await db.execute(
+        select(func.count(BudgetItem.id)).where(BudgetItem.category_id == category_id)
+    )
+    return result.scalar() or 0
+
+
+async def delete_category(db: AsyncSession, category: Category, reassign_to_id: int | None = None) -> None:
+    if reassign_to_id:
+        await db.execute(
+            update(BudgetItem)
+            .where(BudgetItem.category_id == category.id)
+            .values(category_id=reassign_to_id)
+        )
+    await db.delete(category)
+    await db.commit()
 
 
 async def create_category(db: AsyncSession, name: str, category_type: CategoryType) -> Category:


### PR DESCRIPTION
- Add DELETE /api/v1/categories/{category_id} with protection for system categories.

- When budget items exist, requires reassign_to query parameter to move items to another category before deletion.