### PR TITLE
Add plan duplicate endpoint (US-052)

### DIFF
--- a/app/api/v1/endpoints/plans.py
+++ b/app/api/v1/endpoints/plans.py
@@ -70,3 +70,17 @@ async def delete_plan(
     if plan.user_id != current_user.id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to access this plan")
     await plan_crud.delete_plan(db, plan=plan)
+
+
+@router.post("/{plan_id}/duplicate", response_model=PlanResponse, status_code=status.HTTP_201_CREATED)
+async def duplicate_plan(
+    plan_id: int,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    plan = await plan_crud.get_plan_by_id(db, plan_id=plan_id)
+    if not plan:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Plan not found")
+    if plan.user_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to access this plan")
+    return await plan_crud.duplicate_plan(db, source_plan=plan, new_name=f"Kopie von {plan.name}")

--- a/app/crud/plan.py
+++ b/app/crud/plan.py
@@ -50,6 +50,36 @@ async def update_plan(db: AsyncSession, plan: Plan, plan_update: PlanUpdate) -> 
     return plan
 
 
+async def duplicate_plan(db: AsyncSession, source_plan: Plan, new_name: str) -> dict:
+    new_plan = Plan(
+        user_id=source_plan.user_id,
+        name=new_name,
+        description=source_plan.description,
+    )
+    db.add(new_plan)
+    await db.flush()
+
+    items_result = await db.execute(
+        select(BudgetItem).where(BudgetItem.plan_id == source_plan.id)
+    )
+    for item in items_result.scalars().all():
+        new_item = BudgetItem(
+            plan_id=new_plan.id,
+            category_id=item.category_id,
+            description=item.description,
+            amount=item.amount,
+            type=item.type,
+            payment_rhythm=item.payment_rhythm,
+            note=item.note,
+        )
+        db.add(new_item)
+
+    await db.commit()
+    await db.refresh(new_plan)
+    stats = await _get_plan_stats(db, new_plan.id)
+    return _plan_to_dict(new_plan, *stats)
+
+
 async def delete_plan(db: AsyncSession, plan: Plan) -> None:
     await db.delete(plan)
     await db.commit()


### PR DESCRIPTION
- Add POST /api/v1/plans/{plan_id}/duplicate that creates a copy of the plan including all budget items.

- The new plan is named "Kopie von <original name>".