### PR TITLE
Add automated backend test suite (97 tests)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,9 @@ python-multipart==0.0.12
 
 # Export
 reportlab==4.4.10
+
+# Testing
+pytest==8.3.4
+pytest-asyncio==0.24.0
+httpx==0.27.2
+aiosqlite==0.20.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,122 @@
+from contextlib import asynccontextmanager
+
+import pytest_asyncio
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.core.database import Base, get_db
+from app.crud.category import seed_default_categories
+
+TEST_DATABASE_URL = "sqlite+aiosqlite://"
+
+
+# Replace production lifespan with no-op so tests don't touch Supabase
+@asynccontextmanager
+async def _test_lifespan(app):
+    yield
+
+
+app.router.lifespan_context = _test_lifespan
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine(
+        TEST_DATABASE_URL,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with session_maker() as session:
+        await seed_default_categories(session)
+        yield session
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(db_session):
+    async def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+
+    app.dependency_overrides.clear()
+
+
+# --- Helper functions (reusable across test modules) ---
+
+async def register(client: AsyncClient, email="user@example.com", password="password123", name="Test User"):
+    return await client.post("/api/v1/auth/register", json={
+        "email": email,
+        "password": password,
+        "name": name,
+    })
+
+
+async def get_token(client: AsyncClient, email="user@example.com", password="password123") -> str:
+    r = await client.post("/api/v1/auth/token", data={"username": email, "password": password})
+    return r.json()["access_token"]
+
+
+async def auth(client: AsyncClient, email="user@example.com", password="password123") -> dict:
+    token = await get_token(client, email, password)
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def get_expense_category_id(client: AsyncClient, headers: dict) -> int:
+    r = await client.get("/api/v1/categories/?type=expense", headers=headers)
+    return r.json()[0]["id"]
+
+
+async def get_income_category_id(client: AsyncClient, headers: dict) -> int:
+    r = await client.get("/api/v1/categories/?type=income", headers=headers)
+    return r.json()[0]["id"]
+
+
+async def create_plan(client: AsyncClient, headers: dict, name="Testplan", description="") -> dict:
+    r = await client.post("/api/v1/plans/", json={"name": name, "description": description}, headers=headers)
+    return r.json()
+
+
+async def create_budget_item(client: AsyncClient, headers: dict, plan_id: int, **overrides) -> dict:
+    cat_id = await get_expense_category_id(client, headers)
+    payload = {
+        "description": "Testposten",
+        "amount": 100.0,
+        "type": "expense",
+        "category_id": cat_id,
+        "payment_rhythm": "monthly",
+        "note": "",
+        **overrides,
+    }
+    r = await client.post(f"/api/v1/plans/{plan_id}/items/", json=payload, headers=headers)
+    return r
+
+
+# --- Fixtures for common setups ---
+
+@pytest_asyncio.fixture
+async def auth_headers(client):
+    await register(client)
+    return await auth(client)
+
+
+@pytest_asyncio.fixture
+async def second_user_headers(client):
+    await register(client, email="other@example.com", name="Other User")
+    return await auth(client, email="other@example.com")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,112 @@
+"""
+Tests for authentication endpoints:
+  POST /auth/register
+  POST /auth/token
+  GET  /auth/me
+"""
+from tests.conftest import register, get_token
+
+
+class TestRegister:
+    async def test_register_success(self, client):
+        r = await register(client)
+        assert r.status_code == 201
+        data = r.json()
+        assert data["email"] == "user@example.com"
+        assert data["name"] == "Test User"
+        assert "id" in data
+        assert "password" not in data
+
+    async def test_register_duplicate_email(self, client):
+        await register(client)
+        r = await register(client)
+        assert r.status_code == 400
+        assert "already registered" in r.json()["detail"]
+
+    async def test_register_invalid_email(self, client):
+        r = await client.post("/api/v1/auth/register", json={
+            "email": "not-an-email",
+            "password": "password123",
+            "name": "Test",
+        })
+        assert r.status_code == 422
+
+    async def test_register_password_too_short(self, client):
+        r = await client.post("/api/v1/auth/register", json={
+            "email": "short@example.com",
+            "password": "1234567",
+            "name": "Test",
+        })
+        assert r.status_code == 422
+
+    async def test_register_password_max_length(self, client):
+        r = await client.post("/api/v1/auth/register", json={
+            "email": "long@example.com",
+            "password": "a" * 73,
+            "name": "Test",
+        })
+        assert r.status_code == 422
+
+    async def test_register_missing_email(self, client):
+        r = await client.post("/api/v1/auth/register", json={
+            "password": "password123",
+        })
+        assert r.status_code == 422
+
+    async def test_register_without_name(self, client):
+        r = await client.post("/api/v1/auth/register", json={
+            "email": "noname@example.com",
+            "password": "password123",
+        })
+        assert r.status_code == 201
+        assert r.json()["name"] is None
+
+
+class TestLogin:
+    async def test_login_success(self, client):
+        await register(client)
+        r = await client.post("/api/v1/auth/token", data={
+            "username": "user@example.com",
+            "password": "password123",
+        })
+        assert r.status_code == 200
+        data = r.json()
+        assert "access_token" in data
+        assert data["token_type"] == "bearer"
+
+    async def test_login_wrong_password(self, client):
+        await register(client)
+        r = await client.post("/api/v1/auth/token", data={
+            "username": "user@example.com",
+            "password": "wrongpassword",
+        })
+        assert r.status_code == 401
+        assert "Incorrect" in r.json()["detail"]
+
+    async def test_login_nonexistent_user(self, client):
+        r = await client.post("/api/v1/auth/token", data={
+            "username": "ghost@example.com",
+            "password": "password123",
+        })
+        assert r.status_code == 401
+
+    async def test_login_missing_credentials(self, client):
+        r = await client.post("/api/v1/auth/token", data={})
+        assert r.status_code == 422
+
+
+class TestGetMe:
+    async def test_get_me_success(self, client, auth_headers):
+        r = await client.get("/api/v1/auth/me", headers=auth_headers)
+        assert r.status_code == 200
+        data = r.json()
+        assert data["email"] == "user@example.com"
+        assert "id" in data
+
+    async def test_get_me_no_token(self, client):
+        r = await client.get("/api/v1/auth/me")
+        assert r.status_code == 403
+
+    async def test_get_me_invalid_token(self, client):
+        r = await client.get("/api/v1/auth/me", headers={"Authorization": "Bearer invalid.token.here"})
+        assert r.status_code == 401

--- a/tests/test_budget_items.py
+++ b/tests/test_budget_items.py
@@ -1,0 +1,245 @@
+"""
+Tests for budget item endpoints:
+  GET    /plans/{plan_id}/items/
+  POST   /plans/{plan_id}/items/
+  PUT    /plans/{plan_id}/items/{item_id}
+  DELETE /plans/{plan_id}/items/{item_id}
+"""
+import pytest
+from tests.conftest import create_plan, create_budget_item, get_expense_category_id, get_income_category_id
+
+
+class TestListBudgetItems:
+    async def test_list_items_empty(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await client.get(f"/api/v1/plans/{plan['id']}/items/", headers=auth_headers)
+        assert r.status_code == 200
+        assert r.json() == []
+
+    async def test_list_items_unauthenticated(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await client.get(f"/api/v1/plans/{plan['id']}/items/")
+        assert r.status_code == 403
+
+    async def test_list_items_wrong_user(self, client, auth_headers, second_user_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await client.get(f"/api/v1/plans/{plan['id']}/items/", headers=second_user_headers)
+        assert r.status_code == 403
+
+
+class TestCreateBudgetItem:
+    async def test_create_expense_item(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await create_budget_item(client, auth_headers, plan["id"], description="Miete", amount=800.0, type="expense")
+        assert r.status_code == 201
+        data = r.json()
+        assert data["description"] == "Miete"
+        assert data["amount"] == 800.0
+        assert data["type"] == "expense"
+        assert data["monthly_amount"] == 800.0
+
+    async def test_create_income_item(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        cat_id = await get_income_category_id(client, auth_headers)
+        r = await create_budget_item(client, auth_headers, plan["id"],
+                                     description="Gehalt", amount=2500.0,
+                                     type="income", category_id=cat_id)
+        assert r.status_code == 201
+        assert r.json()["type"] == "income"
+
+    async def test_monthly_amount_monthly(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await create_budget_item(client, auth_headers, plan["id"], amount=300.0, payment_rhythm="monthly")
+        assert r.json()["monthly_amount"] == 300.0
+
+    async def test_monthly_amount_quarterly(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await create_budget_item(client, auth_headers, plan["id"], amount=300.0, payment_rhythm="quarterly")
+        assert r.json()["monthly_amount"] == round(300.0 / 3, 2)
+
+    async def test_monthly_amount_semi_annually(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await create_budget_item(client, auth_headers, plan["id"], amount=600.0, payment_rhythm="semi_annually")
+        assert r.json()["monthly_amount"] == round(600.0 / 6, 2)
+
+    async def test_monthly_amount_annually(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await create_budget_item(client, auth_headers, plan["id"], amount=1200.0, payment_rhythm="annually")
+        assert r.json()["monthly_amount"] == round(1200.0 / 12, 2)
+
+    async def test_create_item_with_note(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await create_budget_item(client, auth_headers, plan["id"], note="Faellig im Januar")
+        assert r.status_code == 201
+        assert r.json()["note"] == "Faellig im Januar"
+
+    async def test_create_item_without_note(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await create_budget_item(client, auth_headers, plan["id"], note=None)
+        assert r.status_code == 201
+        assert r.json()["note"] is None
+
+    async def test_create_item_negative_amount(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        cat_id = await get_expense_category_id(client, auth_headers)
+        r = await client.post(f"/api/v1/plans/{plan['id']}/items/", json={
+            "description": "Negativ",
+            "amount": -100.0,
+            "type": "expense",
+            "category_id": cat_id,
+            "payment_rhythm": "monthly",
+        }, headers=auth_headers)
+        assert r.status_code == 422
+
+    async def test_create_item_zero_amount(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        cat_id = await get_expense_category_id(client, auth_headers)
+        r = await client.post(f"/api/v1/plans/{plan['id']}/items/", json={
+            "description": "Null",
+            "amount": 0.0,
+            "type": "expense",
+            "category_id": cat_id,
+            "payment_rhythm": "monthly",
+        }, headers=auth_headers)
+        assert r.status_code == 422
+
+    async def test_create_item_missing_description(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        cat_id = await get_expense_category_id(client, auth_headers)
+        r = await client.post(f"/api/v1/plans/{plan['id']}/items/", json={
+            "amount": 100.0,
+            "type": "expense",
+            "category_id": cat_id,
+            "payment_rhythm": "monthly",
+        }, headers=auth_headers)
+        assert r.status_code == 422
+
+    async def test_create_item_invalid_rhythm(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        cat_id = await get_expense_category_id(client, auth_headers)
+        r = await client.post(f"/api/v1/plans/{plan['id']}/items/", json={
+            "description": "Test",
+            "amount": 100.0,
+            "type": "expense",
+            "category_id": cat_id,
+            "payment_rhythm": "weekly",
+        }, headers=auth_headers)
+        assert r.status_code == 422
+
+    async def test_create_item_plan_not_found(self, client, auth_headers):
+        cat_id = await get_expense_category_id(client, auth_headers)
+        r = await client.post("/api/v1/plans/99999/items/", json={
+            "description": "Test",
+            "amount": 100.0,
+            "type": "expense",
+            "category_id": cat_id,
+            "payment_rhythm": "monthly",
+        }, headers=auth_headers)
+        assert r.status_code == 404
+
+    async def test_create_item_wrong_user(self, client, auth_headers, second_user_headers):
+        plan = await create_plan(client, auth_headers)
+        cat_id = await get_expense_category_id(client, second_user_headers)
+        r = await client.post(f"/api/v1/plans/{plan['id']}/items/", json={
+            "description": "Test",
+            "amount": 100.0,
+            "type": "expense",
+            "category_id": cat_id,
+            "payment_rhythm": "monthly",
+        }, headers=second_user_headers)
+        assert r.status_code == 403
+
+    async def test_create_item_updates_plan_stats(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        await create_budget_item(client, auth_headers, plan["id"], amount=500.0, type="expense", payment_rhythm="monthly")
+        await create_budget_item(client, auth_headers, plan["id"],
+                                 amount=2000.0, type="income", payment_rhythm="monthly",
+                                 category_id=await get_income_category_id(client, auth_headers))
+
+        r = await client.get(f"/api/v1/plans/{plan['id']}", headers=auth_headers)
+        data = r.json()
+        assert data["budget_item_count"] == 2
+        assert data["total_monthly_expenses"] == 500.0
+        assert data["total_monthly_income"] == 2000.0
+        assert data["monthly_balance"] == 1500.0
+
+
+class TestUpdateBudgetItem:
+    async def test_update_item_amount(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        item = (await create_budget_item(client, auth_headers, plan["id"], amount=100.0)).json()
+
+        r = await client.put(f"/api/v1/plans/{plan['id']}/items/{item['id']}",
+                             json={"amount": 250.0}, headers=auth_headers)
+        assert r.status_code == 200
+        assert r.json()["amount"] == 250.0
+        assert r.json()["monthly_amount"] == 250.0
+
+    async def test_update_item_description(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        item = (await create_budget_item(client, auth_headers, plan["id"])).json()
+
+        r = await client.put(f"/api/v1/plans/{plan['id']}/items/{item['id']}",
+                             json={"description": "Neue Bezeichnung"}, headers=auth_headers)
+        assert r.status_code == 200
+        assert r.json()["description"] == "Neue Bezeichnung"
+
+    async def test_update_item_rhythm_recalculates_monthly(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        item = (await create_budget_item(client, auth_headers, plan["id"],
+                                         amount=1200.0, payment_rhythm="monthly")).json()
+        assert item["monthly_amount"] == 1200.0
+
+        r = await client.put(f"/api/v1/plans/{plan['id']}/items/{item['id']}",
+                             json={"payment_rhythm": "annually"}, headers=auth_headers)
+        assert r.status_code == 200
+        assert r.json()["monthly_amount"] == 100.0
+
+    async def test_update_item_not_found(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await client.put(f"/api/v1/plans/{plan['id']}/items/99999",
+                             json={"amount": 100.0}, headers=auth_headers)
+        assert r.status_code == 404
+
+    async def test_update_item_wrong_user(self, client, auth_headers, second_user_headers):
+        plan = await create_plan(client, auth_headers)
+        item = (await create_budget_item(client, auth_headers, plan["id"])).json()
+        r = await client.put(f"/api/v1/plans/{plan['id']}/items/{item['id']}",
+                             json={"amount": 999.0}, headers=second_user_headers)
+        assert r.status_code == 403
+
+
+class TestDeleteBudgetItem:
+    async def test_delete_item_success(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        item = (await create_budget_item(client, auth_headers, plan["id"])).json()
+
+        r = await client.delete(f"/api/v1/plans/{plan['id']}/items/{item['id']}", headers=auth_headers)
+        assert r.status_code == 204
+
+        r = await client.get(f"/api/v1/plans/{plan['id']}/items/", headers=auth_headers)
+        assert r.json() == []
+
+    async def test_delete_item_updates_plan_stats(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        item = (await create_budget_item(client, auth_headers, plan["id"], amount=500.0)).json()
+
+        r = await client.get(f"/api/v1/plans/{plan['id']}", headers=auth_headers)
+        assert r.json()["budget_item_count"] == 1
+
+        await client.delete(f"/api/v1/plans/{plan['id']}/items/{item['id']}", headers=auth_headers)
+
+        r = await client.get(f"/api/v1/plans/{plan['id']}", headers=auth_headers)
+        assert r.json()["budget_item_count"] == 0
+        assert r.json()["total_monthly_expenses"] == 0.0
+
+    async def test_delete_item_not_found(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await client.delete(f"/api/v1/plans/{plan['id']}/items/99999", headers=auth_headers)
+        assert r.status_code == 404
+
+    async def test_delete_item_wrong_user(self, client, auth_headers, second_user_headers):
+        plan = await create_plan(client, auth_headers)
+        item = (await create_budget_item(client, auth_headers, plan["id"])).json()
+        r = await client.delete(f"/api/v1/plans/{plan['id']}/items/{item['id']}", headers=second_user_headers)
+        assert r.status_code == 403

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,206 @@
+"""
+Tests for category endpoints:
+  GET    /categories/
+  POST   /categories/
+  PUT    /categories/{category_id}
+  DELETE /categories/{category_id}
+"""
+import pytest
+from tests.conftest import create_plan, create_budget_item, get_expense_category_id, get_income_category_id
+
+
+async def create_custom_category(client, headers, name="Benutzerdefiniert", type="expense") -> dict:
+    r = await client.post("/api/v1/categories/", json={"name": name, "type": type}, headers=headers)
+    return r.json()
+
+
+class TestListCategories:
+    async def test_list_all_categories(self, client, auth_headers):
+        r = await client.get("/api/v1/categories/", headers=auth_headers)
+        assert r.status_code == 200
+        data = r.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+    async def test_list_categories_contains_system_categories(self, client, auth_headers):
+        r = await client.get("/api/v1/categories/", headers=auth_headers)
+        names = [c["name"] for c in r.json()]
+        assert "Gehalt" in names
+        assert "Miete" in names
+
+    async def test_list_categories_filter_expense(self, client, auth_headers):
+        r = await client.get("/api/v1/categories/?type=expense", headers=auth_headers)
+        assert r.status_code == 200
+        data = r.json()
+        assert len(data) > 0
+        assert all(c["type"] == "expense" for c in data)
+
+    async def test_list_categories_filter_income(self, client, auth_headers):
+        r = await client.get("/api/v1/categories/?type=income", headers=auth_headers)
+        assert r.status_code == 200
+        data = r.json()
+        assert len(data) > 0
+        assert all(c["type"] == "income" for c in data)
+
+    async def test_list_categories_unauthenticated(self, client):
+        r = await client.get("/api/v1/categories/")
+        assert r.status_code == 403
+
+    async def test_list_categories_invalid_type_filter(self, client, auth_headers):
+        r = await client.get("/api/v1/categories/?type=invalid", headers=auth_headers)
+        assert r.status_code == 422
+
+
+class TestCreateCategory:
+    async def test_create_expense_category(self, client, auth_headers):
+        r = await client.post("/api/v1/categories/", json={"name": "Haustiere", "type": "expense"}, headers=auth_headers)
+        assert r.status_code == 201
+        data = r.json()
+        assert data["name"] == "Haustiere"
+        assert data["type"] == "expense"
+        assert data["is_system"] is False
+
+    async def test_create_income_category(self, client, auth_headers):
+        r = await client.post("/api/v1/categories/", json={"name": "Dividenden", "type": "income"}, headers=auth_headers)
+        assert r.status_code == 201
+        data = r.json()
+        assert data["name"] == "Dividenden"
+        assert data["type"] == "income"
+
+    async def test_create_category_duplicate_name(self, client, auth_headers):
+        await client.post("/api/v1/categories/", json={"name": "Duplikat", "type": "expense"}, headers=auth_headers)
+        r = await client.post("/api/v1/categories/", json={"name": "Duplikat", "type": "income"}, headers=auth_headers)
+        assert r.status_code == 409
+
+    async def test_create_category_duplicate_system_name(self, client, auth_headers):
+        r = await client.post("/api/v1/categories/", json={"name": "Miete", "type": "expense"}, headers=auth_headers)
+        assert r.status_code == 409
+
+    async def test_create_category_missing_name(self, client, auth_headers):
+        r = await client.post("/api/v1/categories/", json={"type": "expense"}, headers=auth_headers)
+        assert r.status_code == 422
+
+    async def test_create_category_missing_type(self, client, auth_headers):
+        r = await client.post("/api/v1/categories/", json={"name": "OhneTyp"}, headers=auth_headers)
+        assert r.status_code == 422
+
+    async def test_create_category_invalid_type(self, client, auth_headers):
+        r = await client.post("/api/v1/categories/", json={"name": "Test", "type": "savings"}, headers=auth_headers)
+        assert r.status_code == 422
+
+    async def test_create_category_empty_name(self, client, auth_headers):
+        r = await client.post("/api/v1/categories/", json={"name": "", "type": "expense"}, headers=auth_headers)
+        assert r.status_code == 422
+
+    async def test_create_category_unauthenticated(self, client):
+        r = await client.post("/api/v1/categories/", json={"name": "Test", "type": "expense"})
+        assert r.status_code == 403
+
+    async def test_created_category_appears_in_list(self, client, auth_headers):
+        await client.post("/api/v1/categories/", json={"name": "Neuanlage", "type": "expense"}, headers=auth_headers)
+        r = await client.get("/api/v1/categories/", headers=auth_headers)
+        names = [c["name"] for c in r.json()]
+        assert "Neuanlage" in names
+
+
+class TestUpdateCategory:
+    async def test_update_category_name(self, client, auth_headers):
+        cat = await create_custom_category(client, auth_headers, name="Alter Name")
+        r = await client.put(f"/api/v1/categories/{cat['id']}", json={"name": "Neuer Name"}, headers=auth_headers)
+        assert r.status_code == 200
+        assert r.json()["name"] == "Neuer Name"
+
+    async def test_update_category_same_name(self, client, auth_headers):
+        cat = await create_custom_category(client, auth_headers, name="Unveraendert")
+        r = await client.put(f"/api/v1/categories/{cat['id']}", json={"name": "Unveraendert"}, headers=auth_headers)
+        assert r.status_code == 200
+        assert r.json()["name"] == "Unveraendert"
+
+    async def test_update_category_name_conflict(self, client, auth_headers):
+        await create_custom_category(client, auth_headers, name="Bereits vorhanden")
+        cat = await create_custom_category(client, auth_headers, name="Wird umbenannt")
+        r = await client.put(f"/api/v1/categories/{cat['id']}", json={"name": "Bereits vorhanden"}, headers=auth_headers)
+        assert r.status_code == 409
+
+    async def test_update_system_category_name_conflict(self, client, auth_headers):
+        cat = await create_custom_category(client, auth_headers, name="Meine Kategorie")
+        r = await client.put(f"/api/v1/categories/{cat['id']}", json={"name": "Miete"}, headers=auth_headers)
+        assert r.status_code == 409
+
+    async def test_update_category_not_found(self, client, auth_headers):
+        r = await client.put("/api/v1/categories/99999", json={"name": "X"}, headers=auth_headers)
+        assert r.status_code == 404
+
+    async def test_update_category_missing_name(self, client, auth_headers):
+        cat = await create_custom_category(client, auth_headers)
+        r = await client.put(f"/api/v1/categories/{cat['id']}", json={}, headers=auth_headers)
+        assert r.status_code == 422
+
+    async def test_update_category_unauthenticated(self, client, auth_headers):
+        cat = await create_custom_category(client, auth_headers)
+        r = await client.put(f"/api/v1/categories/{cat['id']}", json={"name": "X"})
+        assert r.status_code == 403
+
+
+class TestDeleteCategory:
+    async def test_delete_custom_category_success(self, client, auth_headers):
+        cat = await create_custom_category(client, auth_headers, name="ZumLoeschen")
+        r = await client.delete(f"/api/v1/categories/{cat['id']}", headers=auth_headers)
+        assert r.status_code == 204
+
+    async def test_delete_category_no_longer_in_list(self, client, auth_headers):
+        cat = await create_custom_category(client, auth_headers, name="Verschwindet")
+        await client.delete(f"/api/v1/categories/{cat['id']}", headers=auth_headers)
+        r = await client.get("/api/v1/categories/", headers=auth_headers)
+        names = [c["name"] for c in r.json()]
+        assert "Verschwindet" not in names
+
+    async def test_delete_system_category_forbidden(self, client, auth_headers):
+        expense_cat_id = await get_expense_category_id(client, auth_headers)
+        r = await client.delete(f"/api/v1/categories/{expense_cat_id}", headers=auth_headers)
+        assert r.status_code == 403
+
+    async def test_delete_category_with_items_no_reassign(self, client, auth_headers):
+        cat = await create_custom_category(client, auth_headers, name="MitPosten")
+        plan = await create_plan(client, auth_headers)
+        await create_budget_item(client, auth_headers, plan["id"], category_id=cat["id"])
+
+        r = await client.delete(f"/api/v1/categories/{cat['id']}", headers=auth_headers)
+        assert r.status_code == 409
+
+    async def test_delete_category_with_items_and_reassign(self, client, auth_headers):
+        cat = await create_custom_category(client, auth_headers, name="AltKategorie")
+        new_cat = await create_custom_category(client, auth_headers, name="NeuKategorie")
+        plan = await create_plan(client, auth_headers)
+        item_r = await create_budget_item(client, auth_headers, plan["id"], category_id=cat["id"])
+        item = item_r.json()
+
+        r = await client.delete(
+            f"/api/v1/categories/{cat['id']}?reassign_to={new_cat['id']}",
+            headers=auth_headers,
+        )
+        assert r.status_code == 204
+
+        r = await client.get(f"/api/v1/plans/{plan['id']}/items/", headers=auth_headers)
+        items = r.json()
+        assert any(i["id"] == item["id"] and i["category_id"] == new_cat["id"] for i in items)
+
+    async def test_delete_category_reassign_target_not_found(self, client, auth_headers):
+        cat = await create_custom_category(client, auth_headers, name="OhneZiel")
+        plan = await create_plan(client, auth_headers)
+        await create_budget_item(client, auth_headers, plan["id"], category_id=cat["id"])
+
+        r = await client.delete(
+            f"/api/v1/categories/{cat['id']}?reassign_to=99999",
+            headers=auth_headers,
+        )
+        assert r.status_code == 404
+
+    async def test_delete_category_not_found(self, client, auth_headers):
+        r = await client.delete("/api/v1/categories/99999", headers=auth_headers)
+        assert r.status_code == 404
+
+    async def test_delete_category_unauthenticated(self, client, auth_headers):
+        cat = await create_custom_category(client, auth_headers)
+        r = await client.delete(f"/api/v1/categories/{cat['id']}")
+        assert r.status_code == 403

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1,0 +1,177 @@
+"""
+Tests for plan endpoints:
+  GET    /plans/
+  POST   /plans/
+  GET    /plans/{id}
+  PUT    /plans/{id}
+  DELETE /plans/{id}
+  POST   /plans/{id}/duplicate
+  GET    /plans/{id}/export/pdf
+  GET    /plans/{id}/export/csv
+"""
+from tests.conftest import register, auth, create_plan, create_budget_item, get_expense_category_id
+
+
+class TestListPlans:
+    async def test_list_plans_empty(self, client, auth_headers):
+        r = await client.get("/api/v1/plans/", headers=auth_headers)
+        assert r.status_code == 200
+        assert r.json() == []
+
+    async def test_list_plans_returns_own_plans_only(self, client, auth_headers, second_user_headers):
+        await create_plan(client, auth_headers, name="Plan A")
+        await create_plan(client, auth_headers, name="Plan B")
+        await create_plan(client, second_user_headers, name="Other Plan")
+
+        r = await client.get("/api/v1/plans/", headers=auth_headers)
+        assert r.status_code == 200
+        names = [p["name"] for p in r.json()]
+        assert "Plan A" in names
+        assert "Plan B" in names
+        assert "Other Plan" not in names
+
+    async def test_list_plans_unauthenticated(self, client):
+        r = await client.get("/api/v1/plans/")
+        assert r.status_code == 403
+
+
+class TestCreatePlan:
+    async def test_create_plan_success(self, client, auth_headers):
+        r = await client.post("/api/v1/plans/", json={"name": "Haushaltsplan", "description": "Monatlich"}, headers=auth_headers)
+        assert r.status_code == 201
+        data = r.json()
+        assert data["name"] == "Haushaltsplan"
+        assert data["description"] == "Monatlich"
+        assert data["budget_item_count"] == 0
+        assert data["total_monthly_income"] == 0.0
+        assert data["total_monthly_expenses"] == 0.0
+        assert data["monthly_balance"] == 0.0
+
+    async def test_create_plan_without_description(self, client, auth_headers):
+        r = await client.post("/api/v1/plans/", json={"name": "Nur Name"}, headers=auth_headers)
+        assert r.status_code == 201
+        assert r.json()["description"] is None
+
+    async def test_create_plan_missing_name(self, client, auth_headers):
+        r = await client.post("/api/v1/plans/", json={"description": "Kein Name"}, headers=auth_headers)
+        assert r.status_code == 422
+
+    async def test_create_plan_empty_name(self, client, auth_headers):
+        r = await client.post("/api/v1/plans/", json={"name": ""}, headers=auth_headers)
+        assert r.status_code == 422
+
+    async def test_create_plan_unauthenticated(self, client):
+        r = await client.post("/api/v1/plans/", json={"name": "Test"})
+        assert r.status_code == 403
+
+
+class TestGetPlan:
+    async def test_get_plan_success(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await client.get(f"/api/v1/plans/{plan['id']}", headers=auth_headers)
+        assert r.status_code == 200
+        assert r.json()["id"] == plan["id"]
+
+    async def test_get_plan_not_found(self, client, auth_headers):
+        r = await client.get("/api/v1/plans/99999", headers=auth_headers)
+        assert r.status_code == 404
+
+    async def test_get_plan_wrong_user(self, client, auth_headers, second_user_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await client.get(f"/api/v1/plans/{plan['id']}", headers=second_user_headers)
+        assert r.status_code == 403
+
+    async def test_get_plan_includes_stats(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        await create_budget_item(client, auth_headers, plan["id"], amount=1200.0, payment_rhythm="annually", type="expense")
+
+        r = await client.get(f"/api/v1/plans/{plan['id']}", headers=auth_headers)
+        data = r.json()
+        assert data["budget_item_count"] == 1
+        assert data["total_monthly_expenses"] == round(1200.0 / 12, 2)
+        assert data["monthly_balance"] == round(-1200.0 / 12, 2)
+
+
+class TestUpdatePlan:
+    async def test_update_plan_success(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers, name="Alt")
+        r = await client.put(f"/api/v1/plans/{plan['id']}", json={"name": "Neu", "description": "Aktualisiert"}, headers=auth_headers)
+        assert r.status_code == 200
+        assert r.json()["name"] == "Neu"
+        assert r.json()["description"] == "Aktualisiert"
+
+    async def test_update_plan_not_found(self, client, auth_headers):
+        r = await client.put("/api/v1/plans/99999", json={"name": "X"}, headers=auth_headers)
+        assert r.status_code == 404
+
+    async def test_update_plan_wrong_user(self, client, auth_headers, second_user_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await client.put(f"/api/v1/plans/{plan['id']}", json={"name": "X"}, headers=second_user_headers)
+        assert r.status_code == 403
+
+
+class TestDeletePlan:
+    async def test_delete_plan_success(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await client.delete(f"/api/v1/plans/{plan['id']}", headers=auth_headers)
+        assert r.status_code == 204
+
+        r = await client.get(f"/api/v1/plans/{plan['id']}", headers=auth_headers)
+        assert r.status_code == 404
+
+    async def test_delete_plan_not_found(self, client, auth_headers):
+        r = await client.delete("/api/v1/plans/99999", headers=auth_headers)
+        assert r.status_code == 404
+
+    async def test_delete_plan_wrong_user(self, client, auth_headers, second_user_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await client.delete(f"/api/v1/plans/{plan['id']}", headers=second_user_headers)
+        assert r.status_code == 403
+
+    async def test_delete_plan_cascades_items(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        await create_budget_item(client, auth_headers, plan["id"])
+
+        await client.delete(f"/api/v1/plans/{plan['id']}", headers=auth_headers)
+        r = await client.get("/api/v1/plans/", headers=auth_headers)
+        assert all(p["id"] != plan["id"] for p in r.json())
+
+
+class TestDuplicatePlan:
+    async def test_duplicate_plan_success(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers, name="Original")
+        await create_budget_item(client, auth_headers, plan["id"], description="Miete", amount=800.0)
+
+        r = await client.post(f"/api/v1/plans/{plan['id']}/duplicate", headers=auth_headers)
+        assert r.status_code == 201
+        data = r.json()
+        assert "Kopie von" in data["name"]
+        assert data["budget_item_count"] == 1
+
+    async def test_duplicate_plan_not_found(self, client, auth_headers):
+        r = await client.post("/api/v1/plans/99999/duplicate", headers=auth_headers)
+        assert r.status_code == 404
+
+    async def test_duplicate_plan_wrong_user(self, client, auth_headers, second_user_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await client.post(f"/api/v1/plans/{plan['id']}/duplicate", headers=second_user_headers)
+        assert r.status_code == 403
+
+
+class TestExports:
+    async def test_pdf_export(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await client.get(f"/api/v1/plans/{plan['id']}/export/pdf", headers=auth_headers)
+        assert r.status_code == 200
+        assert r.headers["content-type"] == "application/pdf"
+
+    async def test_csv_export(self, client, auth_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await client.get(f"/api/v1/plans/{plan['id']}/export/csv", headers=auth_headers)
+        assert r.status_code == 200
+        assert "text/csv" in r.headers["content-type"]
+
+    async def test_export_wrong_user(self, client, auth_headers, second_user_headers):
+        plan = await create_plan(client, auth_headers)
+        r = await client.get(f"/api/v1/plans/{plan['id']}/export/pdf", headers=second_user_headers)
+        assert r.status_code == 403


### PR DESCRIPTION
- tests/conftest.py: shared fixtures with SQLite in-memory DB, lifespan override, helper functions for auth/plans/items

- tests/test_auth.py: 13 tests for register, login, /me endpoints

- tests/test_plans.py: 18 tests for plan CRUD, duplicate, PDF/CSV export

- tests/test_budget_items.py: 22 tests for budget item CRUD, payment rhythm calculation, plan stats updates

- tests/test_categories.py: 24 tests for category CRUD, system category protection, item reassignment on delete

All 97 tests passing, covers happy path and edge cases