### PR TITLE
Implement Strategy Pattern for plan export services

### DIFF
--- a/app/api/v1/endpoints/plans.py
+++ b/app/api/v1/endpoints/plans.py
@@ -1,5 +1,4 @@
 from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.responses import Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_db
@@ -8,8 +7,7 @@ from app.crud import budget_item as budget_item_crud
 from app.schemas.plan import PlanCreate, PlanUpdate, PlanResponse
 from app.api.deps import get_current_user
 from app.models.user import User
-from app.services.pdf_export import generate_plan_pdf
-from app.services.excel_export import generate_plan_excel
+from app.services.export_strategy import ExportContext, PDFExportStrategy, ExcelExportStrategy
 
 router = APIRouter()
 
@@ -102,12 +100,8 @@ async def export_plan_pdf(
     if plan.user_id != current_user.id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to access this plan")
     items = await budget_item_crud.get_budget_items_with_category(db, plan_id=plan_id)
-    pdf_bytes = generate_plan_pdf(plan.name, plan.description, items)
-    return Response(
-        content=pdf_bytes,
-        media_type="application/pdf",
-        headers={"Content-Disposition": f'attachment; filename="{plan.name}.pdf"'},
-    )
+    context = ExportContext(PDFExportStrategy())
+    return context.build_response(plan.name, plan.description, items)
 
 
 @router.get("/{plan_id}/export/csv")
@@ -122,9 +116,5 @@ async def export_plan_csv(
     if plan.user_id != current_user.id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not authorized to access this plan")
     items = await budget_item_crud.get_budget_items_with_category(db, plan_id=plan_id)
-    xlsx_bytes = generate_plan_excel(plan.name, plan.description, items)
-    return Response(
-        content=xlsx_bytes,
-        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        headers={"Content-Disposition": f'attachment; filename="{plan.name}.xlsx"'},
-    )
+    context = ExportContext(ExcelExportStrategy())
+    return context.build_response(plan.name, plan.description, items)

--- a/app/services/export_strategy.py
+++ b/app/services/export_strategy.py
@@ -1,0 +1,56 @@
+from abc import ABC, abstractmethod
+from fastapi.responses import Response
+
+
+class ExportStrategy(ABC):
+    @abstractmethod
+    def generate(self, plan_name: str, plan_description: str | None, items: list[dict]) -> bytes:
+        pass
+
+    @abstractmethod
+    def media_type(self) -> str:
+        pass
+
+    @abstractmethod
+    def filename(self, plan_name: str) -> str:
+        pass
+
+
+class PDFExportStrategy(ExportStrategy):
+    def generate(self, plan_name: str, plan_description: str | None, items: list[dict]) -> bytes:
+        from app.services.pdf_export import generate_plan_pdf
+        return generate_plan_pdf(plan_name, plan_description, items)
+
+    def media_type(self) -> str:
+        return "application/pdf"
+
+    def filename(self, plan_name: str) -> str:
+        return f"{plan_name}.pdf"
+
+
+class ExcelExportStrategy(ExportStrategy):
+    def generate(self, plan_name: str, plan_description: str | None, items: list[dict]) -> bytes:
+        from app.services.excel_export import generate_plan_excel
+        return generate_plan_excel(plan_name, plan_description, items)
+
+    def media_type(self) -> str:
+        return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+    def filename(self, plan_name: str) -> str:
+        return f"{plan_name}.xlsx"
+
+
+class ExportContext:
+    def __init__(self, strategy: ExportStrategy):
+        self._strategy = strategy
+
+    def set_strategy(self, strategy: ExportStrategy) -> None:
+        self._strategy = strategy
+
+    def build_response(self, plan_name: str, plan_description: str | None, items: list[dict]) -> Response:
+        file_bytes = self._strategy.generate(plan_name, plan_description, items)
+        return Response(
+            content=file_bytes,
+            media_type=self._strategy.media_type(),
+            headers={"Content-Disposition": f'attachment; filename="{self._strategy.filename(plan_name)}"'},
+        )


### PR DESCRIPTION
Add ExportStrategy ABC with PDFExportStrategy and ExcelExportStrategy as concrete implementations. Introduce ExportContext to decouple endpoints from strategy selection and response construction.

Export endpoints now only instantiate a context with the appropriate strategy - all media type, filename, and byte generation logic is encapsulated in the strategy classes.